### PR TITLE
Move Death Logic to Abstract Class for Code Reusability

### DIFF
--- a/lib/characters/character_animation.dart
+++ b/lib/characters/character_animation.dart
@@ -79,7 +79,10 @@ abstract class CharacterAnimation extends SpriteAnimationComponent
 
   void move(Set<LogicalKeyboardKey> keysPressed);
   void jump(Set<LogicalKeyboardKey> keysPressed);
-  void dead();
+  void dead() {
+    AudioManager.playSound(AudioType.death);
+    resetPosition();
+  }
 
   void resetPosition() {
     position = initialPosition;

--- a/lib/characters/fireboy/fireboy.dart
+++ b/lib/characters/fireboy/fireboy.dart
@@ -34,10 +34,4 @@ class FireboyAnimation extends CharacterAnimation {
       animation = idleAnimation;
     }
   }
-  
-  @override
-  void dead() {
-    AudioManager.playSound(AudioType.death);
-    resetPosition();
-  }
 }

--- a/lib/characters/watergirl/watergirl.dart
+++ b/lib/characters/watergirl/watergirl.dart
@@ -34,10 +34,4 @@ class WaterGirlAnimation extends CharacterAnimation {
       animation = idleAnimation;
     }
   }
-  
-  @override
-  void dead() {
-    AudioManager.playSound(AudioType.death);
-    resetPosition();
-  }
 }


### PR DESCRIPTION
This refactor removes the duplicated dead() method from FireboyAnimation and WaterGirlAnimation, consolidating it into the CharacterAnimation abstract class. This improves code maintainability, reduces redundancy, and ensures that all character animations share the same death behavior.

- Moved dead() method to CharacterAnimation.
- Removed dead() method from FireboyAnimation and WaterGirlAnimation.
- Ensured both characters now inherit the same death logic.

This change makes the code cleaner and more modular, facilitating future modifications or enhancements.