### PR TITLE
Add Live Demo Link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This is a learning project built with Flutter and Flame Engine, inspired by Fire
 # 🎯 Purpose
 This project was built just for learning and practice. It is not an official or commercial game, but an experiment to understand game mechanics, physics, and multiplayer logic in Flutter.
 
+# 🚀 Live Demo
+Try out the game here: [Live Demo](https://domingomg.github.io/fireboy_watergirl_flutter/)
+
 ## 📸 Screenshots
 
 ### **🕹️ Main Menu**


### PR DESCRIPTION
This pull request adds a live demo link to the README file, allowing users to easily test the game online. The link has been added under a new "🚀 Live Demo" section to improve accessibility and visibility.

This update enhances the documentation by providing a direct way to experience the project without requiring local setup.

Let me know if any further modifications are needed. 🚀